### PR TITLE
feat: add cmux terminal multiplexer support with pluggable backend sy…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,11 +27,14 @@ Pods/
 *.swp
 *.swo
 *~
+.codebase-architecture-analyzer/
 
 # IDE
 .idea/
 *.iml
 .vscode/
+.bsp/
+.sourcekit-lsp/
 
 # Sparkle signing keys (NEVER commit these!)
 .sparkle-keys/
@@ -41,10 +44,13 @@ releases/
 
 # Xcode backup
 *.xcodeproj.backup/
-CLAUDE.md
-
 
 bridge-rs/target/*
 bridge-rs/target/.*
 
 AgentIsland/Resources/agent-island-bridge
+
+# Code agents
+.agents
+.claude
+skills-lock.json

--- a/AgentIsland/App/AppDelegate.swift
+++ b/AgentIsland/App/AppDelegate.swift
@@ -4,6 +4,7 @@ import Mixpanel
 import Sparkle
 import SwiftUI
 
+@MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
     private var windowManager: WindowManager?
     private var screenObserver: ScreenObserver?

--- a/AgentIsland/App/WindowManager.swift
+++ b/AgentIsland/App/WindowManager.swift
@@ -11,6 +11,7 @@ import os.log
 /// Logger for window management
 private let logger = Logger(subsystem: "com.agentisland", category: "Window")
 
+@MainActor
 class WindowManager {
     private(set) var windowController: NotchWindowController?
 

--- a/AgentIsland/Core/Settings.swift
+++ b/AgentIsland/Core/Settings.swift
@@ -31,6 +31,15 @@ enum NotificationSound: String, CaseIterable {
     }
 }
 
+enum TerminalBackend: String, CaseIterable {
+    case tmux
+    case cmux
+
+    var displayName: String {
+        rawValue
+    }
+}
+
 enum AppSettings {
     private static let defaults = UserDefaults.standard
 
@@ -38,6 +47,7 @@ enum AppSettings {
 
     private enum Keys {
         static let notificationSound = "notificationSound"
+        static let terminalBackend = "terminalBackend"
         static let codexDangerousCommandPatterns = "codexDangerousCommandPatterns"
     }
 
@@ -54,6 +64,21 @@ enum AppSettings {
         }
         set {
             defaults.set(newValue.rawValue, forKey: Keys.notificationSound)
+        }
+    }
+
+    // MARK: - Terminal Backend
+
+    static var terminalBackend: TerminalBackend {
+        get {
+            guard let rawValue = defaults.string(forKey: Keys.terminalBackend),
+                  let backend = TerminalBackend(rawValue: rawValue) else {
+                return .tmux // Default to tmux
+            }
+            return backend
+        }
+        set {
+            defaults.set(newValue.rawValue, forKey: Keys.terminalBackend)
         }
     }
 

--- a/AgentIsland/Models/CmuxTarget.swift
+++ b/AgentIsland/Models/CmuxTarget.swift
@@ -1,0 +1,18 @@
+//
+//  CmuxTarget.swift
+//  Agent Island
+//
+//  Data model for cmux workspace/surface targeting
+//
+
+import Foundation
+
+struct CmuxTarget: Sendable {
+    let workspaceId: String
+    let surfaceId: String
+
+    init(workspaceId: String, surfaceId: String) {
+        self.workspaceId = workspaceId
+        self.surfaceId = surfaceId
+    }
+}

--- a/AgentIsland/Models/SessionListState.swift
+++ b/AgentIsland/Models/SessionListState.swift
@@ -15,7 +15,7 @@ struct SessionListState: Equatable, Identifiable, Sendable {
     let projectName: String
     let pid: Int?
     let tty: String?
-    let isInTmux: Bool
+    let isInTerminalMultiplexer: Bool
     let phase: SessionPhase
     let conversationInfo: ConversationInfo
     let lastActivity: Date

--- a/AgentIsland/Models/SessionState.swift
+++ b/AgentIsland/Models/SessionState.swift
@@ -25,7 +25,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
 
     var pid: Int?
     var tty: String?
-    var isInTmux: Bool
+    var isInTerminalMultiplexer: Bool
 
     // MARK: - State Machine
 
@@ -77,7 +77,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         projectName: String? = nil,
         pid: Int? = nil,
         tty: String? = nil,
-        isInTmux: Bool = false,
+        isInTerminalMultiplexer: Bool = false,
         phase: SessionPhase = .idle,
         phaseSources: SessionPhaseSources? = nil,
         chatItems: [ChatHistoryItem] = [],
@@ -95,7 +95,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         self.projectName = projectName ?? URL(fileURLWithPath: cwd).lastPathComponent
         self.pid = pid
         self.tty = tty
-        self.isInTmux = isInTmux
+        self.isInTerminalMultiplexer = isInTerminalMultiplexer
         self.phase = phase
         self.phaseSources = phaseSources ?? Self.defaultPhaseSources
         self.chatItems = chatItems
@@ -214,7 +214,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
             projectName: projectName,
             pid: pid,
             tty: tty,
-            isInTmux: isInTmux,
+            isInTerminalMultiplexer: isInTerminalMultiplexer,
             phase: phase,
             conversationInfo: conversationInfo,
             lastActivity: lastActivity,

--- a/AgentIsland/Services/Cmux/CmuxController.swift
+++ b/AgentIsland/Services/Cmux/CmuxController.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+actor CmuxController {
+    static let shared = CmuxController()
+
+    private init() {}
+
+    func findTarget(forTTY tty: String, agentPid: Int? = nil) async -> CmuxTarget? {
+        await CmuxTargetFinder.shared.findTarget(forTTY: tty, agentPid: agentPid)
+    }
+
+    func findTarget(forAgentPid pid: Int) async -> CmuxTarget? {
+        await CmuxTargetFinder.shared.findTarget(forAgentPid: pid)
+    }
+
+    func findTarget(forWorkingDirectory dir: String) async -> CmuxTarget? {
+        await CmuxTargetFinder.shared.findTarget(forWorkingDirectory: dir)
+    }
+
+    func sendMessage(_ message: String, to target: CmuxTarget) async -> Bool {
+        await CmuxRPCClient.shared.sendText(message, surfaceId: target.surfaceId)
+    }
+
+    func sendSpecialKey(_ key: TmuxSpecialKey, to target: CmuxTarget) async -> Bool {
+        let mapped: String
+        switch key {
+        case .escape:
+            mapped = "escape"
+        }
+        return await CmuxRPCClient.shared.sendKey(mapped, surfaceId: target.surfaceId)
+    }
+
+    func switchToTarget(_ target: CmuxTarget) async -> Bool {
+        let switched = await CmuxRPCClient.shared.selectWorkspace(target.workspaceId)
+        guard switched else { return false }
+        return await CmuxRPCClient.shared.focusSurface(target.surfaceId)
+    }
+
+    func isSessionTargetActive(agentPid: Int) async -> Bool {
+        await CmuxTargetFinder.shared.isSessionTargetActive(agentPid: agentPid)
+    }
+}

--- a/AgentIsland/Services/Cmux/CmuxRPCClient.swift
+++ b/AgentIsland/Services/Cmux/CmuxRPCClient.swift
@@ -1,0 +1,87 @@
+import Foundation
+import os.log
+
+actor CmuxRPCClient {
+    nonisolated static let logger = Logger(subsystem: "com.agentisland", category: "CmuxRPC")
+    static let shared = CmuxRPCClient()
+
+    private init() {}
+
+    private let defaultSocketPath = "/tmp/cmux.sock"
+
+    private func socketPath() -> String {
+        if let env = Foundation.ProcessInfo.processInfo.environment["CMUX_SOCKET_PATH"], !env.isEmpty {
+            return env
+        }
+        return defaultSocketPath
+    }
+
+    private func rpc(_ method: String, params: [String: Any] = [:]) async -> [String: Any]? {
+        let request: [String: Any] = [
+            "id": UUID().uuidString,
+            "method": method,
+            "params": params
+        ]
+
+        guard let requestData = try? JSONSerialization.data(withJSONObject: request),
+              let payload = String(data: requestData, encoding: .utf8) else {
+            return nil
+        }
+
+        let socket = socketPath()
+        let cmd = "cat <<'EOF' | nc -U \"\(socket)\"\n\(payload)\nEOF"
+
+        let result = await ProcessExecutor.shared.runWithResult("/bin/sh", arguments: ["-lc", cmd])
+        guard case .success(let processResult) = result else {
+            Self.logger.error("cmux rpc failed method=\(method, privacy: .public) socket=\(socket, privacy: .public)")
+            return nil
+        }
+
+        let line = processResult.output
+            .components(separatedBy: CharacterSet.newlines)
+            .first { !$0.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).isEmpty }
+
+        guard let line,
+              let data = line.data(using: String.Encoding.utf8),
+              let response = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let ok = response["ok"] as? Bool,
+              ok == true else {
+            Self.logger.error("cmux rpc bad response method=\(method, privacy: .public) raw=\(processResult.output, privacy: .public)")
+            return nil
+        }
+
+        if let rpcResult = response["result"] as? [String: Any] {
+            return rpcResult
+        }
+
+        return [:]
+    }
+
+    func identify() async -> [String: Any]? {
+        await rpc("system.identify")
+    }
+
+    func currentWorkspace() async -> [String: Any]? {
+        await rpc("workspace.current")
+    }
+
+    func listSurfaces() async -> [String: Any]? {
+        await rpc("surface.list")
+    }
+
+    func sendText(_ text: String, surfaceId: String) async -> Bool {
+        await rpc("surface.send_text", params: ["surface_id": surfaceId, "text": text + "\n"]) != nil
+    }
+
+    func sendKey(_ key: String, surfaceId: String) async -> Bool {
+        await rpc("surface.send_key", params: ["surface_id": surfaceId, "key": key]) != nil
+    }
+
+    func focusSurface(_ surfaceId: String) async -> Bool {
+        await rpc("surface.focus", params: ["surface_id": surfaceId]) != nil
+    }
+
+    func selectWorkspace(_ workspaceId: String) async -> Bool {
+        await rpc("workspace.select", params: ["workspace_id": workspaceId]) != nil
+    }
+}

--- a/AgentIsland/Services/Cmux/CmuxTargetFinder.swift
+++ b/AgentIsland/Services/Cmux/CmuxTargetFinder.swift
@@ -1,0 +1,137 @@
+import Foundation
+import os.log
+
+actor CmuxTargetFinder {
+    static let shared = CmuxTargetFinder()
+
+    private init() {}
+
+    func findTarget(forTTY tty: String, agentPid: Int? = nil) async -> CmuxTarget? {
+        guard let workspaceId = await currentWorkspaceId() else {
+            CmuxRPCClient.logger.error("cmux target resolve failed: missing workspace for tty=\(tty)")
+            return nil
+        }
+
+        if let surfaceId = await findSurfaceIdByTTY(tty) {
+            return CmuxTarget(workspaceId: workspaceId, surfaceId: surfaceId)
+        }
+
+        if let agentPid,
+           let targetFromEnv = findTargetFromProcessEnvironment(agentPid: agentPid, fallbackWorkspaceId: workspaceId) {
+            return targetFromEnv
+        }
+
+        if let identified = await CmuxRPCClient.shared.identify() {
+            let focused = identified["focused"] as? [String: Any]
+            if let surfaceId = focused?["surface_id"] as? String,
+               let focusedWorkspaceId = focused?["workspace_id"] as? String {
+                return CmuxTarget(workspaceId: focusedWorkspaceId, surfaceId: surfaceId)
+            }
+            if let surfaceId = identified["surface_id"] as? String,
+               let identifiedWorkspaceId = identified["workspace_id"] as? String {
+                return CmuxTarget(workspaceId: identifiedWorkspaceId, surfaceId: surfaceId)
+            }
+        }
+
+        CmuxRPCClient.logger.error("cmux target resolve failed: no surface matched tty=\(tty)")
+        return nil
+    }
+
+    func findTarget(forAgentPid agentPid: Int) async -> CmuxTarget? {
+        let tree = ProcessTreeBuilder.shared.buildTree()
+        guard let tty = tree[agentPid]?.tty else {
+            return nil
+        }
+        return await findTarget(forTTY: tty)
+    }
+
+    func findTarget(forWorkingDirectory workingDirectory: String) async -> CmuxTarget? {
+        guard let workspaceId = await currentWorkspaceId() else {
+            return nil
+        }
+
+        guard let response = await CmuxRPCClient.shared.listSurfaces(),
+              let surfaces = response["surfaces"] as? [[String: Any]] else {
+            return nil
+        }
+
+        for surface in surfaces {
+            guard let surfaceId = surface["surface_id"] as? String else { continue }
+            if let cwd = surface["cwd"] as? String, cwd == workingDirectory {
+                return CmuxTarget(workspaceId: workspaceId, surfaceId: surfaceId)
+            }
+        }
+
+        return nil
+    }
+
+    func isSessionTargetActive(agentPid: Int) async -> Bool {
+        guard let target = await findTarget(forAgentPid: agentPid),
+              let identified = await CmuxRPCClient.shared.identify(),
+              let activeSurfaceId = identified["surface_id"] as? String else {
+            return false
+        }
+
+        return target.surfaceId == activeSurfaceId
+    }
+
+    private func currentWorkspaceId() async -> String? {
+        if let response = await CmuxRPCClient.shared.currentWorkspace(),
+           let id = response["workspace_id"] as? String {
+            return id
+        }
+
+        if let identify = await CmuxRPCClient.shared.identify() {
+            let focused = identify["focused"] as? [String: Any]
+            if let id = focused?["workspace_id"] as? String {
+                return id
+            }
+            if let id = identify["workspace_id"] as? String {
+                return id
+            }
+        }
+
+        return nil
+    }
+
+    private func findTargetFromProcessEnvironment(agentPid: Int, fallbackWorkspaceId: String) -> CmuxTarget? {
+        guard let envOutput = ProcessExecutor.shared.runSyncOrNil("/bin/ps", arguments: ["eww", "-p", String(agentPid)]) else {
+            return nil
+        }
+
+        if let surfaceId = extractEnvValue("CMUX_SURFACE_ID", from: envOutput) {
+            let workspaceId = extractEnvValue("CMUX_WORKSPACE_ID", from: envOutput) ?? fallbackWorkspaceId
+            return CmuxTarget(workspaceId: workspaceId, surfaceId: surfaceId)
+        }
+
+        return nil
+    }
+
+    private func extractEnvValue(_ key: String, from text: String) -> String? {
+        guard let range = text.range(of: "\(key)=") else {
+            return nil
+        }
+        let substring = text[range.upperBound...]
+        let value = substring.prefix { !$0.isWhitespace }
+        return value.isEmpty ? nil : String(value)
+    }
+
+    private func findSurfaceIdByTTY(_ tty: String) async -> String? {
+        guard let response = await CmuxRPCClient.shared.listSurfaces(),
+              let surfaces = response["surfaces"] as? [[String: Any]] else {
+            return nil
+        }
+
+        for surface in surfaces {
+            guard let surfaceId = surface["surface_id"] as? String else { continue }
+            if let surfaceTTY = surface["tty"] as? String {
+                let normalized = surfaceTTY.replacingOccurrences(of: "/dev/", with: "")
+                if normalized == tty {
+                    return surfaceId
+                }
+            }
+        }
+
+        return nil
+    }
+}

--- a/AgentIsland/Services/Session/AgentRuntimeObserver.swift
+++ b/AgentIsland/Services/Session/AgentRuntimeObserver.swift
@@ -227,51 +227,52 @@ private struct TmuxAgentInteractionAdapter: AgentInteractionAdapter {
     let supportsMessaging: Bool
     let supportsSessionControl = true
 
+    private func backendAdapter() -> any TerminalMultiplexerAdapter {
+        TerminalMultiplexerRegistry.shared.adapter(for: AppSettings.terminalBackend)
+    }
+
     nonisolated func canSendMessages(in session: SessionState) -> Bool {
-        supportsMessaging && session.isInTmux && session.tty != nil
+        supportsMessaging && session.isInTerminalMultiplexer && session.tty != nil
     }
 
     func sendMessage(_ message: String, in session: SessionState) async -> Bool {
-        guard let tty = session.tty,
-              let target = await TmuxController.shared.findTmuxTarget(forTTY: tty) else {
+        guard let tty = session.tty else {
             return false
         }
 
-        return await TmuxController.shared.sendMessage(message, to: target)
+        return await backendAdapter().sendMessage(message, tty: tty, agentPid: session.pid)
     }
 
     nonisolated func canInterruptTurn(in session: SessionState) -> Bool {
-        agentType.terminalControlProfile.supportsInterrupt && session.isInTmux && session.tty != nil
+        agentType.terminalControlProfile.supportsInterrupt && session.isInTerminalMultiplexer && session.tty != nil
     }
 
     func interruptTurn(in session: SessionState) async -> Bool {
         guard canInterruptTurn(in: session),
-              let tty = session.tty,
-              let target = await TmuxController.shared.findTmuxTarget(forTTY: tty) else {
+              let tty = session.tty else {
             return false
         }
 
-        return await TmuxController.shared.sendSpecialKey(.escape, to: target)
+        return await backendAdapter().sendSpecialKey(.escape, tty: tty, agentPid: session.pid)
     }
 
     nonisolated func canTerminateSession(in session: SessionState) -> Bool {
-        agentType.terminalControlProfile.exitCommand != nil && session.isInTmux && session.tty != nil
+        agentType.terminalControlProfile.exitCommand != nil && session.isInTerminalMultiplexer && session.tty != nil
     }
 
     func terminateSession(in session: SessionState) async -> Bool {
         guard canTerminateSession(in: session),
               let exitCommand = agentType.terminalControlProfile.exitCommand,
-              let tty = session.tty,
-              let target = await TmuxController.shared.findTmuxTarget(forTTY: tty) else {
+              let tty = session.tty else {
             return false
         }
 
         if session.phase.isActive || session.phase.isWaitingForApproval {
-            _ = await TmuxController.shared.sendSpecialKey(.escape, to: target)
+            _ = await backendAdapter().sendSpecialKey(.escape, tty: tty, agentPid: session.pid)
             try? await Task.sleep(for: .milliseconds(120))
         }
 
-        return await TmuxController.shared.sendMessage(exitCommand.text, to: target)
+        return await backendAdapter().sendMessage(exitCommand.text, tty: tty, agentPid: session.pid)
     }
 }
 

--- a/AgentIsland/Services/Shared/ProcessTreeBuilder.swift
+++ b/AgentIsland/Services/Shared/ProcessTreeBuilder.swift
@@ -54,14 +54,19 @@ struct ProcessTreeBuilder: Sendable {
         return tree
     }
 
-    /// Check if a process has tmux in its parent chain
-    nonisolated func isInTmux(pid: Int, tree: [Int: ProcessInfo]) -> Bool {
+    /// Check if a process has the selected terminal multiplexer in its parent chain.
+    nonisolated func isInTerminalMultiplexer(
+        pid: Int,
+        tree: [Int: ProcessInfo],
+        backend: TerminalBackend = AppSettings.terminalBackend
+    ) -> Bool {
         var current = pid
         var depth = 0
+        let target = backend.rawValue.lowercased()
 
         while current > 1 && depth < 20 {
             guard let info = tree[current] else { break }
-            if info.command.lowercased().contains("tmux") {
+            if info.command.lowercased().contains(target) {
                 return true
             }
             current = info.ppid

--- a/AgentIsland/Services/State/SessionStore.swift
+++ b/AgentIsland/Services/State/SessionStore.swift
@@ -143,7 +143,7 @@ actor SessionStore {
         }
         if let pid = event.pid {
             let tree = ProcessTreeBuilder.shared.buildTree()
-            session.isInTmux = ProcessTreeBuilder.shared.isInTmux(pid: pid, tree: tree)
+            session.isInTerminalMultiplexer = ProcessTreeBuilder.shared.isInTerminalMultiplexer(pid: pid, tree: tree)
         }
         if let tty = event.tty {
             session.tty = tty.replacingOccurrences(of: "/dev/", with: "")
@@ -203,15 +203,16 @@ actor SessionStore {
             projectName: URL(fileURLWithPath: event.cwd).lastPathComponent,
             pid: event.pid,
             tty: event.tty?.replacingOccurrences(of: "/dev/", with: ""),
-            isInTmux: false,  // Will be updated
+            isInTerminalMultiplexer: false,  // Will be updated
             phase: phase,
             phaseSources: SessionPhaseSources(hook: phase, transcript: nil, runtime: nil)
         )
     }
 
     private func shouldRetainEndedSession(_ session: SessionState) async -> Bool {
-        if session.isInTmux, let tty = session.tty {
-            if await TmuxController.shared.findTmuxTarget(forTTY: tty) != nil {
+        if session.isInTerminalMultiplexer, let tty = session.tty {
+            let adapter = TerminalMultiplexerRegistry.shared.adapter(for: AppSettings.terminalBackend)
+            if await adapter.hasTarget(forTTY: tty) {
                 return true
             }
         }

--- a/AgentIsland/Services/Terminal/CmuxTerminalMultiplexerAdapter.swift
+++ b/AgentIsland/Services/Terminal/CmuxTerminalMultiplexerAdapter.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+final actor CmuxTerminalMultiplexerAdapter: TerminalMultiplexerAdapter {
+    static let shared = CmuxTerminalMultiplexerAdapter()
+
+    let backend: TerminalBackend = .cmux
+
+    private init() {}
+
+    func hasTarget(forTTY tty: String) async -> Bool {
+        await CmuxController.shared.findTarget(forTTY: tty) != nil
+    }
+
+    func sendMessage(_ message: String, tty: String, agentPid: Int?) async -> Bool {
+        guard let target = await CmuxController.shared.findTarget(forTTY: tty, agentPid: agentPid) else {
+            return false
+        }
+        return await CmuxController.shared.sendMessage(message, to: target)
+    }
+
+    func sendSpecialKey(_ key: TmuxSpecialKey, tty: String, agentPid: Int?) async -> Bool {
+        guard let target = await CmuxController.shared.findTarget(forTTY: tty, agentPid: agentPid) else {
+            return false
+        }
+        return await CmuxController.shared.sendSpecialKey(key, to: target)
+    }
+
+    func isSessionTargetActive(agentPid: Int) async -> Bool {
+        await CmuxController.shared.isSessionTargetActive(agentPid: agentPid)
+    }
+}

--- a/AgentIsland/Services/Terminal/TerminalMultiplexerAdapter.swift
+++ b/AgentIsland/Services/Terminal/TerminalMultiplexerAdapter.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+protocol TerminalMultiplexerAdapter {
+    var backend: TerminalBackend { get }
+
+    func hasTarget(forTTY tty: String) async -> Bool
+    func sendMessage(_ message: String, tty: String, agentPid: Int?) async -> Bool
+    func sendSpecialKey(_ key: TmuxSpecialKey, tty: String, agentPid: Int?) async -> Bool
+    func isSessionTargetActive(agentPid: Int) async -> Bool
+}

--- a/AgentIsland/Services/Terminal/TerminalMultiplexerRegistry.swift
+++ b/AgentIsland/Services/Terminal/TerminalMultiplexerRegistry.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct TerminalMultiplexerRegistry {
+    nonisolated static let shared = TerminalMultiplexerRegistry()
+
+    private init() {}
+
+    func adapter(for backend: TerminalBackend) -> any TerminalMultiplexerAdapter {
+        switch backend {
+        case .tmux:
+            return TmuxTerminalMultiplexerAdapter.shared
+        case .cmux:
+            return CmuxTerminalMultiplexerAdapter.shared
+        }
+    }
+}

--- a/AgentIsland/Services/Terminal/TmuxTerminalMultiplexerAdapter.swift
+++ b/AgentIsland/Services/Terminal/TmuxTerminalMultiplexerAdapter.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+final actor TmuxTerminalMultiplexerAdapter: TerminalMultiplexerAdapter {
+    static let shared = TmuxTerminalMultiplexerAdapter()
+
+    let backend: TerminalBackend = .tmux
+
+    private init() {}
+
+    func hasTarget(forTTY tty: String) async -> Bool {
+        await TmuxController.shared.findTmuxTarget(forTTY: tty) != nil
+    }
+
+    func sendMessage(_ message: String, tty: String, agentPid _: Int?) async -> Bool {
+        guard let target = await TmuxController.shared.findTmuxTarget(forTTY: tty) else {
+            return false
+        }
+        return await TmuxController.shared.sendMessage(message, to: target)
+    }
+
+    func sendSpecialKey(_ key: TmuxSpecialKey, tty: String, agentPid _: Int?) async -> Bool {
+        guard let target = await TmuxController.shared.findTmuxTarget(forTTY: tty) else {
+            return false
+        }
+        return await TmuxController.shared.sendSpecialKey(key, to: target)
+    }
+
+    func isSessionTargetActive(agentPid: Int) async -> Bool {
+        await TmuxTargetFinder.shared.isSessionPaneActive(agentPid: agentPid)
+    }
+}

--- a/AgentIsland/Services/Window/YabaiController.swift
+++ b/AgentIsland/Services/Window/YabaiController.swift
@@ -15,67 +15,74 @@ actor YabaiController {
 
     // MARK: - Public API
 
-    /// Focus the terminal window for a given agent PID (tmux only)
-    func focusWindow(forAgentPid agentPid: Int) async -> Bool {
+    /// Focus the terminal window for a given agent PID.
+    func focusWindow(forAgentPid agentPid: Int, terminalBackend: TerminalBackend = AppSettings.terminalBackend) async -> Bool {
         guard await WindowFinder.shared.isYabaiAvailable() else {
             return false
         }
 
-        let windows = await WindowFinder.shared.getAllWindows()
-        let tree = ProcessTreeBuilder.shared.buildTree()
+        switch terminalBackend {
+        case .tmux:
+            let windows = await WindowFinder.shared.getAllWindows()
+            let tree = ProcessTreeBuilder.shared.buildTree()
+            guard let target = await TmuxController.shared.findTmuxTarget(forAgentPid: agentPid) else {
+                return false
+            }
 
-        return await focusTmuxInstance(agentPid: agentPid, tree: tree, windows: windows)
+            _ = await TmuxController.shared.switchToPane(target: target)
+            if let terminalPid = await findTerminalPidForTmuxSession(target.session, tree: tree, windows: windows) {
+                return await WindowFocuser.shared.focusTmuxWindow(terminalPid: terminalPid, windows: windows)
+            }
+            return false
+
+        case .cmux:
+            guard let target = await CmuxController.shared.findTarget(forAgentPid: agentPid) else {
+                return false
+            }
+            return await CmuxController.shared.switchToTarget(target)
+        }
     }
 
-    /// Focus the terminal window for a given working directory (tmux only, fallback)
-    func focusWindow(forWorkingDirectory workingDirectory: String) async -> Bool {
+    /// Focus the terminal window for a given working directory (fallback path).
+    func focusWindow(forWorkingDirectory workingDirectory: String, terminalBackend: TerminalBackend = AppSettings.terminalBackend) async -> Bool {
         guard await WindowFinder.shared.isYabaiAvailable() else { return false }
 
-        return await focusWindow(forWorkingDir: workingDirectory)
-    }
+        switch terminalBackend {
+        case .tmux:
+            let windows = await WindowFinder.shared.getAllWindows()
+            let tree = ProcessTreeBuilder.shared.buildTree()
+            guard let target = await TmuxController.shared.findTmuxTarget(forWorkingDirectory: workingDirectory) else {
+                return false
+            }
 
-    // MARK: - Private Implementation
-
-    private func focusTmuxInstance(agentPid: Int, tree: [Int: ProcessInfo], windows: [YabaiWindow]) async -> Bool {
-        // Find the tmux target for this agent process
-        guard let target = await TmuxController.shared.findTmuxTarget(forAgentPid: agentPid) else {
+            _ = await TmuxController.shared.switchToPane(target: target)
+            if let terminalPid = await findTerminalPidForTmuxSession(target.session, tree: tree, windows: windows) {
+                return await WindowFocuser.shared.focusTmuxWindow(terminalPid: terminalPid, windows: windows)
+            }
             return false
+
+        case .cmux:
+            guard let target = await CmuxController.shared.findTarget(forWorkingDirectory: workingDirectory) else {
+                return false
+            }
+            return await CmuxController.shared.switchToTarget(target)
         }
-
-        // Switch to the correct pane
-        _ = await TmuxController.shared.switchToPane(target: target)
-
-        // Find terminal for this specific tmux session
-        if let terminalPid = await findTmuxClientTerminal(forSession: target.session, tree: tree, windows: windows) {
-            return await WindowFocuser.shared.focusTmuxWindow(terminalPid: terminalPid, windows: windows)
-        }
-
-        return false
-    }
-
-    private func focusWindow(forWorkingDir workingDir: String) async -> Bool {
-        let windows = await WindowFinder.shared.getAllWindows()
-        let tree = ProcessTreeBuilder.shared.buildTree()
-
-        return await focusTmuxPane(forWorkingDir: workingDir, tree: tree, windows: windows)
     }
 
     // MARK: - Tmux Helpers
 
-    private func findTmuxClientTerminal(forSession session: String, tree: [Int: ProcessInfo], windows: [YabaiWindow]) async -> Int? {
+    private func findTerminalPidForTmuxSession(_ session: String, tree: [Int: ProcessInfo], windows: [YabaiWindow]) async -> Int? {
         guard let tmuxPath = await TmuxPathFinder.shared.getTmuxPath() else { return nil }
 
         do {
-            // Get clients attached to this specific session
             let output = try await ProcessExecutor.shared.run(tmuxPath, arguments: [
                 "list-clients", "-t", session, "-F", "#{client_pid}"
             ])
 
             let clientPids = output.components(separatedBy: "\n")
-                .compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+                .compactMap { Int($0.trimmingCharacters(in: CharacterSet.whitespaces)) }
 
             let windowPids = Set(windows.map { $0.pid })
-
             for clientPid in clientPids {
                 var currentPid = clientPid
                 while currentPid > 1 {
@@ -93,55 +100,8 @@ actor YabaiController {
         return nil
     }
 
-    /// Check if command is a terminal (nonisolated helper to avoid MainActor access)
     private nonisolated func isTerminalProcess(_ command: String) -> Bool {
         let terminalCommands = ["Terminal", "iTerm", "iTerm2", "Alacritty", "kitty", "WezTerm", "wezterm-gui", "Hyper"]
         return terminalCommands.contains { command.contains($0) }
-    }
-
-    private func focusTmuxPane(forWorkingDir workingDir: String, tree: [Int: ProcessInfo], windows: [YabaiWindow]) async -> Bool {
-        guard let tmuxPath = await TmuxPathFinder.shared.getTmuxPath() else { return false }
-
-        do {
-            let panesOutput = try await ProcessExecutor.shared.run(tmuxPath, arguments: [
-                "list-panes", "-a", "-F", "#{session_name}:#{window_index}.#{pane_index}|#{pane_pid}"
-            ])
-
-            let panes = panesOutput.components(separatedBy: "\n").filter { !$0.isEmpty }
-
-            for pane in panes {
-                let parts = pane.components(separatedBy: "|")
-                guard parts.count >= 2,
-                      let panePid = Int(parts[1]) else { continue }
-
-                let targetString = parts[0]
-
-                // Check if this pane has an agent child with matching cwd
-                for (pid, info) in tree {
-                    let isChild = ProcessTreeBuilder.shared.isDescendant(targetPid: pid, ofAncestor: panePid, tree: tree)
-                    let isSupportedAgent = AgentPlatform.detect(fromCommand: info.command) != nil
-
-                    guard isChild, isSupportedAgent else { continue }
-
-                    guard let cwd = ProcessTreeBuilder.shared.getWorkingDirectory(forPid: pid),
-                          cwd == workingDir else { continue }
-
-                    // Found matching pane - switch to it
-                    if let target = TmuxTarget(from: targetString) {
-                        _ = await TmuxController.shared.switchToPane(target: target)
-
-                        // Focus the terminal window for this session
-                        if let terminalPid = await findTmuxClientTerminal(forSession: target.session, tree: tree, windows: windows) {
-                            return await WindowFocuser.shared.focusTmuxWindow(terminalPid: terminalPid, windows: windows)
-                        }
-                    }
-                    return true
-                }
-            }
-        } catch {
-            return false
-        }
-
-        return false
     }
 }

--- a/AgentIsland/UI/Components/TerminalOptionRow.swift
+++ b/AgentIsland/UI/Components/TerminalOptionRow.swift
@@ -1,0 +1,46 @@
+//
+//  TerminalOptionRow.swift
+//  Agent Island
+//
+//  Single option row inside the terminal backend picker
+//
+
+import SwiftUI
+
+struct TerminalOptionRow: View {
+    let label: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(isSelected ? TerminalColors.green : Color.white.opacity(0.2))
+                    .frame(width: 6, height: 6)
+
+                Text(label)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.white.opacity(isHovered ? 1.0 : 0.7))
+
+                Spacer()
+
+                if isSelected {
+                    Image(agentIcon: "checkmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(TerminalColors.green)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isHovered ? Color.white.opacity(0.06) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}

--- a/AgentIsland/UI/Components/TerminalPickerRow.swift
+++ b/AgentIsland/UI/Components/TerminalPickerRow.swift
@@ -1,0 +1,83 @@
+//
+//  TerminalPickerRow.swift
+//  Agent Island
+//
+//  Terminal backend selection picker for settings menu
+//
+
+import SwiftUI
+
+struct TerminalPickerRow: View {
+    @State private var isHovered = false
+    @State private var isExpanded = false
+    @State private var selectedBackend: TerminalBackend = AppSettings.terminalBackend
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 10) {
+                    Image(agentIcon: "terminal")
+                        .font(.system(size: 12))
+                        .foregroundStyle(textColor)
+                        .frame(width: 16)
+
+                    Text("Terminal")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(textColor)
+
+                    Spacer()
+
+                    Text(selectedBackend.displayName)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.white.opacity(0.4))
+                        .lineLimit(1)
+
+                    Image(agentIcon: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.white.opacity(0.4))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isHovered ? Color.white.opacity(0.08) : Color.clear)
+                )
+            }
+            .buttonStyle(.plain)
+            .onHover { isHovered = $0 }
+
+            if isExpanded {
+                VStack(spacing: 2) {
+                    ForEach(TerminalBackend.allCases, id: \.self) { backend in
+                        TerminalOptionRow(
+                            label: backend.displayName,
+                            isSelected: selectedBackend == backend
+                        ) {
+                            selectedBackend = backend
+                            AppSettings.terminalBackend = backend
+                            Task {
+                                try? await Task.sleep(for: .seconds(0.3))
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    isExpanded = false
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.leading, 28)
+                .padding(.top, 4)
+            }
+        }
+        .onAppear {
+            selectedBackend = AppSettings.terminalBackend
+        }
+    }
+
+    private var textColor: Color {
+        .white.opacity(isHovered ? 1.0 : 0.7)
+    }
+}

--- a/AgentIsland/UI/Views/ChatView.swift
+++ b/AgentIsland/UI/Views/ChatView.swift
@@ -415,7 +415,7 @@ struct ChatView: View {
         if canSendMessages {
             return "Message \(session.agentType.displayName)..."
         }
-        return "Open \(session.agentType.displayName) in tmux to enable messaging"
+        return "Open \(session.agentType.displayName) in \(AppSettings.terminalBackend.displayName) to enable messaging"
     }
 
     private var inputBar: some View {
@@ -474,7 +474,7 @@ struct ChatView: View {
             toolInput: session.pendingToolInput,
             agentType: session.agentType,
             supportedActions: session.agentType.approvalCapability.supportedActions,
-            isInTmux: session.isInTmux,
+            isInTerminalMultiplexer: session.isInTerminalMultiplexer,
             onAction: { action in handleApprovalAction(action) }
         )
     }
@@ -484,7 +484,7 @@ struct ChatView: View {
             tool: tool,
             toolInput: session.pendingToolInput,
             agentName: session.agentType.displayName,
-            isInTmux: session.isInTmux,
+            isInTerminalMultiplexer: session.isInTerminalMultiplexer,
             onGoToTerminal: { focusTerminal() }
         )
     }
@@ -495,7 +495,7 @@ struct ChatView: View {
     private var interactivePromptBar: some View {
         ChatInteractivePromptBar(
             agentName: session.agentType.displayName,
-            isInTmux: session.isInTmux,
+            isInTerminalMultiplexer: session.isInTerminalMultiplexer,
             onGoToTerminal: { focusTerminal() }
         )
     }
@@ -518,11 +518,12 @@ struct ChatView: View {
     // MARK: - Actions
 
     private func focusTerminal() {
+        let backend = AppSettings.terminalBackend
         Task {
             if let pid = session.pid {
-                _ = await YabaiController.shared.focusWindow(forAgentPid: pid)
+                _ = await YabaiController.shared.focusWindow(forAgentPid: pid, terminalBackend: backend)
             } else {
-                _ = await YabaiController.shared.focusWindow(forWorkingDirectory: session.cwd)
+                _ = await YabaiController.shared.focusWindow(forWorkingDirectory: session.cwd, terminalBackend: backend)
             }
             await MainActor.run {
                 viewModel.notchClose()
@@ -567,7 +568,12 @@ struct ChatView: View {
     }
 
     private func sendToSession(_ text: String) async {
-        _ = await AgentInteractionRegistry.shared.sendMessage(text, for: session)
+        let sent = await AgentInteractionRegistry.shared.sendMessage(text, for: session)
+        if !sent {
+            await MainActor.run {
+                inputText = text
+            }
+        }
     }
 
     private func interruptTurn() {
@@ -1106,7 +1112,7 @@ struct InterruptedMessageView: View {
 /// Bar for interactive tools like AskUserQuestion that need terminal input
 struct ChatInteractivePromptBar: View {
     let agentName: String
-    let isInTmux: Bool
+    let isInTerminalMultiplexer: Bool
     let onGoToTerminal: () -> Void
 
     @State private var showContent = false
@@ -1129,7 +1135,7 @@ struct ChatInteractivePromptBar: View {
                         .font(.system(size: 13, weight: .semibold, design: .monospaced))
                         .foregroundColor(TerminalColors.amber)
                         .fixedSize()
-                    Text(isInTmux ? "\(agentName) needs your input in Terminal" : "Terminal jump unavailable for this session")
+                    Text(isInTerminalMultiplexer ? "\(agentName) needs your input in Terminal" : "Terminal jump unavailable for this session")
                         .font(.system(size: 12))
                         .foregroundColor(.white.opacity(0.75))
                         .fixedSize(horizontal: false, vertical: true)
@@ -1139,20 +1145,20 @@ struct ChatInteractivePromptBar: View {
             .offset(x: showContent ? 0 : -10)
 
             Button {
-                if isInTmux {
+                if isInTerminalMultiplexer {
                     onGoToTerminal()
                 }
             } label: {
                 HStack(spacing: 4) {
                     Image(agentIcon: "terminal")
                         .font(.system(size: 11, weight: .medium))
-                    Text(isInTmux ? "Jump to Terminal" : "Terminal unavailable")
+                    Text(isInTerminalMultiplexer ? "Jump to Terminal" : "Terminal unavailable")
                         .font(.system(size: 13, weight: .medium))
                 }
-                .foregroundColor(isInTmux ? .black : .white.opacity(0.4))
+                .foregroundColor(isInTerminalMultiplexer ? .black : .white.opacity(0.4))
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 10)
-                .background(isInTmux ? Color.white.opacity(0.95) : Color.white.opacity(0.1))
+                .background(isInTerminalMultiplexer ? Color.white.opacity(0.95) : Color.white.opacity(0.1))
                 .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             }
             .buttonStyle(.plain)
@@ -1189,7 +1195,7 @@ struct ChatApprovalBar: View {
     let toolInput: String?
     let agentType: AgentPlatform
     let supportedActions: [ApprovalAction]
-    let isInTmux: Bool
+    let isInTerminalMultiplexer: Bool
     let onAction: (ApprovalAction) -> Void
 
     @State private var showContent = false
@@ -1238,7 +1244,7 @@ struct ChatApprovalBar: View {
 
             HStack(spacing: 8) {
                 ForEach(supportedActions, id: \.self) { action in
-                    let isEnabled = action != .terminal || isInTmux
+                    let isEnabled = action != .terminal || isInTerminalMultiplexer
                     Button {
                         if isEnabled {
                             onAction(action)
@@ -1320,7 +1326,7 @@ struct ChatTerminalApprovalBar: View {
     let tool: String
     let toolInput: String?
     let agentName: String
-    let isInTmux: Bool
+    let isInTerminalMultiplexer: Bool
     let onGoToTerminal: () -> Void
 
     @State private var showContent = false
@@ -1343,7 +1349,7 @@ struct ChatTerminalApprovalBar: View {
                         .font(.system(size: 13, weight: .semibold, design: .monospaced))
                         .foregroundColor(TerminalColors.amber)
                         .fixedSize()
-                    Text(toolInput ?? (isInTmux ? "\(agentName) needs approval in Terminal" : "Terminal jump unavailable for this session"))
+                    Text(toolInput ?? (isInTerminalMultiplexer ? "\(agentName) needs approval in Terminal" : "Terminal jump unavailable for this session"))
                         .font(.system(size: 12))
                         .foregroundColor(.white.opacity(0.75))
                         .fixedSize(horizontal: false, vertical: true)
@@ -1358,13 +1364,13 @@ struct ChatTerminalApprovalBar: View {
                 HStack(spacing: 4) {
                     Image(agentIcon: "terminal")
                         .font(.system(size: 11, weight: .medium))
-                    Text(isInTmux ? "Jump to Terminal" : "Terminal unavailable")
+                    Text(isInTerminalMultiplexer ? "Jump to Terminal" : "Terminal unavailable")
                         .font(.system(size: 13, weight: .medium))
                 }
-                .foregroundColor(isInTmux ? .black : .white.opacity(0.4))
+                .foregroundColor(isInTerminalMultiplexer ? .black : .white.opacity(0.4))
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 10)
-                .background(isInTmux ? Color.white.opacity(0.95) : Color.white.opacity(0.1))
+                .background(isInTerminalMultiplexer ? Color.white.opacity(0.95) : Color.white.opacity(0.1))
                 .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             }
             .buttonStyle(.plain)
@@ -1393,7 +1399,7 @@ struct ChatTerminalApprovalBar: View {
     }
 
     private func focusIfPossible() {
-        if isInTmux {
+        if isInTerminalMultiplexer {
             onGoToTerminal()
         }
     }

--- a/AgentIsland/UI/Views/ClaudeInstancesView.swift
+++ b/AgentIsland/UI/Views/ClaudeInstancesView.swift
@@ -120,13 +120,14 @@ struct AgentInstancesView: View {
     // MARK: - Actions
 
     private func focusSession(_ session: SessionListState) {
-        guard session.isInTmux else { return }
+        guard session.isInTerminalMultiplexer else { return }
 
+        let backend = AppSettings.terminalBackend
         Task {
             if let pid = session.pid {
-                _ = await YabaiController.shared.focusWindow(forAgentPid: pid)
+                _ = await YabaiController.shared.focusWindow(forAgentPid: pid, terminalBackend: backend)
             } else {
-                _ = await YabaiController.shared.focusWindow(forWorkingDirectory: session.cwd)
+                _ = await YabaiController.shared.focusWindow(forWorkingDirectory: session.cwd, terminalBackend: backend)
             }
             await MainActor.run {
                 viewModel.notchClose()
@@ -300,7 +301,7 @@ struct InstanceRow: View {
                 onChat()
             }
 
-            if session.isInTmux && isYabaiAvailable {
+            if session.isInTerminalMultiplexer && isYabaiAvailable {
                 IconButton(icon: "arrow.up.right") {
                     onFocus()
                 }
@@ -319,7 +320,7 @@ struct InstanceRow: View {
     }
 
     private var showsJumpState: Bool {
-        session.phase == .waitingForInput && session.isInTmux && !isWaitingForApproval
+        session.phase == .waitingForInput && session.isInTerminalMultiplexer && !isWaitingForApproval
     }
 
     @ViewBuilder
@@ -353,7 +354,7 @@ struct InstanceRow: View {
             if isInteractiveTool {
                 ListAskBar(
                     agentName: session.agentType.displayName,
-                    isEnabled: session.isInTmux,
+                    isEnabled: session.isInTerminalMultiplexer,
                     onTap: onFocus
                 )
                 .transition(.opacity.combined(with: .scale(scale: 0.9)))
@@ -361,7 +362,7 @@ struct InstanceRow: View {
                 ListTerminalApprovalBar(
                     tool: session.pendingToolName ?? "exec_command",
                     toolInput: session.pendingToolInput,
-                    isEnabled: session.isInTmux,
+                    isEnabled: session.isInTerminalMultiplexer,
                     onTap: onFocus
                 )
                 .transition(.opacity.combined(with: .scale(scale: 0.9)))
@@ -372,7 +373,7 @@ struct InstanceRow: View {
                 toolInput: session.pendingToolInput,
                 agentType: session.agentType,
                 supportedActions: session.agentType.approvalCapability.supportedActions,
-                isTerminalEnabled: session.isInTmux,
+                isTerminalEnabled: session.isInTerminalMultiplexer,
                 onAction: handleApprovalAction
             )
             .transition(.opacity.combined(with: .scale(scale: 0.9)))

--- a/AgentIsland/UI/Views/NotchMenuView.swift
+++ b/AgentIsland/UI/Views/NotchMenuView.swift
@@ -199,6 +199,7 @@ struct NotchMenuView: View {
     @ViewBuilder
     private var rootContent: some View {
         ScreenPickerRow(screenSelector: screenSelector)
+        TerminalPickerRow()
         SoundPickerRow(soundSelector: soundSelector)
 
         Divider()

--- a/AgentIsland/Utilities/TerminalVisibilityDetector.swift
+++ b/AgentIsland/Utilities/TerminalVisibilityDetector.swift
@@ -50,11 +50,11 @@ struct TerminalVisibilityDetector {
         }
 
         let tree = ProcessTreeBuilder.shared.buildTree()
-        let isInTmux = ProcessTreeBuilder.shared.isInTmux(pid: sessionPid, tree: tree)
+        let isInTerminalMultiplexer = ProcessTreeBuilder.shared.isInTerminalMultiplexer(pid: sessionPid, tree: tree)
 
-        if isInTmux {
-            // For tmux sessions, check if the session's pane is active
-            return await TmuxTargetFinder.shared.isSessionPaneActive(agentPid: sessionPid)
+        if isInTerminalMultiplexer {
+            let adapter = TerminalMultiplexerRegistry.shared.adapter(for: AppSettings.terminalBackend)
+            return await adapter.isSessionTargetActive(agentPid: sessionPid)
         } else {
             // For non-tmux sessions, check if the session's terminal app is frontmost
             guard let sessionTerminalPid = ProcessTreeBuilder.shared.findTerminalPid(forProcess: sessionPid, tree: tree),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,108 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build, test, and development commands
+
+### Main app (macOS SwiftUI)
+
+- Build app + bridge (default local flow):
+  - `./scripts/build.sh`
+- Build app in unsigned mode (CI-style / local without signing):
+  - `AGENT_ISLAND_NO_SIGN=1 ./scripts/build.sh`
+- Build in Xcode via CLI (Debug):
+  - `xcodebuild build -project AgentIsland.xcodeproj -scheme AgentIsland -configuration Debug`
+- Resolve Swift package dependencies:
+  - `xcodebuild -resolvePackageDependencies -project AgentIsland.xcodeproj -scheme AgentIsland`
+
+### Rust bridge (`bridge-rs`)
+
+- Build release bridge binary:
+  - `./scripts/build-rust-bridge.sh`
+  - or `cargo build --release --manifest-path bridge-rs/Cargo.toml`
+- Run bridge tests:
+  - `cargo test --manifest-path bridge-rs/Cargo.toml`
+- Run a single Rust test:
+  - `cargo test --manifest-path bridge-rs/Cargo.toml <test_name>`
+
+### Lint / analysis
+
+This repo does not define a dedicated lint script. Use platform-native checks:
+
+- Swift static analysis:
+  - `xcodebuild analyze -project AgentIsland.xcodeproj -scheme AgentIsland -configuration Debug`
+- Rust linting / formatting checks:
+  - `cargo clippy --manifest-path bridge-rs/Cargo.toml --all-targets -- -D warnings`
+  - `cargo fmt --manifest-path bridge-rs/Cargo.toml --check`
+
+### Packaging / release helpers
+
+- Local release packaging workflow (notarization/DMG/appcast/release automation helper):
+  - `./scripts/create-release.sh`
+
+## High-level architecture
+
+AgentIsland is a macOS menu bar runtime that normalizes hook events from multiple CLI agents (Claude, Codex, Gemini) into one internal protocol and one shared UI/state engine.
+
+### Core runtime layers
+
+1. Official hook protocols (agent-specific)
+   - Each agent emits its own hook/event format.
+
+2. Rust bridge normalization (`bridge-rs`)
+   - Entrypoint: `bridge-rs/src/main.rs`
+   - Dispatch: `bridge-rs/src/dispatcher.rs`
+   - Shared payload model: `bridge-rs/src/protocol.rs`
+   - Agent adapters: `bridge-rs/src/adapter/{claude,codex,gemini}.rs`
+   - Output is a normalized `HookPayload` with stable fields used by Swift.
+
+3. Swift ingress and state engine
+   - Socket ingress server: `AgentIsland/Services/Hooks/HookSocketServer.swift`
+   - Central state machine: `AgentIsland/Services/State/SessionStore.swift`
+   - Event bus scaffold: `AgentIsland/Services/Shared/AgentEventBus.swift`
+
+4. UI layer
+   - App/bootstrap: `AgentIsland/App/AppDelegate.swift`
+   - Notch/menu/chat views under `AgentIsland/UI/**`
+
+### Internal protocol contract (important)
+
+UI/state logic should prefer normalized fields from bridge payloads over raw official event names:
+
+- `internal_event` (primary business event)
+- `permission_mode` (approval handling mode)
+- `extra` (agent-specific passthrough)
+
+Reference: `docs/internal-hook-protocol.md`.
+
+### Permission and hook installation model
+
+- Plugin-based hook installation/repair/uninstall is implemented in:
+  - `AgentIsland/Services/Hooks/AgentHookPlugin.swift`
+- Hooks are installed for Claude/Codex/Gemini and call the shared `agent-island-bridge` binary.
+- Bridge binary distribution target is under `~/.agent-island/hooks/agent-island-bridge`.
+
+### Session and transcript model
+
+- `SessionStore` is the single source of truth for session lifecycle, phase transitions, tool timeline, permission state, and chat item state.
+- Transcript/history capability is agent-aware via transcript providers (wired through session services); incremental file sync updates feed back into `SessionStore`.
+- Subagent (`Task`) tool tracking is integrated into session state and chat tool items.
+
+### Release/CI shape
+
+- CI workflow: `.github/workflows/ci-build.yml`
+- CI builds app unsigned (`AGENT_ISLAND_NO_SIGN=1`), packages DMG/ZIP artifacts, and creates tag-based releases.
+- `scripts/build.sh` is the canonical local build entrypoint; it ensures Rust bridge availability and embeds `agent-island-bridge` into the app bundle resources.
+
+## Project map (high signal only)
+
+- `AgentIsland/` — Swift app/runtime/UI
+- `bridge-rs/` — Rust multi-agent hook bridge
+- `docs/` — protocol + architecture + extension docs
+- `scripts/` — build/release/signing helper scripts
+
+## Docs to read before non-trivial changes
+
+1. `docs/internal-hook-protocol.md`
+2. `docs/multi-agent-architecture.md`
+3. `docs/agent-extension-guide.md`

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This keeps UI logic stable while allowing agent-specific differences to live ins
 - [Internal Hook Protocol](./docs/internal-hook-protocol.md)
 - [Multi-Agent Architecture Draft](./docs/multi-agent-architecture.md)
 - [Agent Extension Guide](./docs/agent-extension-guide.md)
+- [Terminal Interaction Guide](./docs/terminal-interaction.md)
 
 ## Quick Start
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -83,10 +83,14 @@ AgentIsland 当前采用三层模型：
 ## 文档导航
 
 - [文档索引](./docs/README.zh.md)
-- [内部 Hook 协议](./docs/internal-hook-protocol.zh.md)
-- [多 Agent 架构草案](./docs/multi-agent-architecture.zh.md)
+- [内部 Hook 协议（英文）](./docs/internal-hook-protocol.md)
+- [内部 Hook 协议（中文）](./docs/internal-hook-protocol.zh.md)
+- [多 Agent 架构草案（英文）](./docs/multi-agent-architecture.md)
+- [多 Agent 架构草案（中文）](./docs/multi-agent-architecture.zh.md)
 - [Agent 扩展指南（英文）](./docs/agent-extension-guide.md)
 - [Agent 扩展指南（中文）](./docs/agent-extension-guide.zh.md)
+- [终端交互指南（英文）](./docs/terminal-interaction.md)
+- [终端交互指南（中文）](./docs/terminal-interaction.zh.md)
 
 ## 快速开始
 

--- a/docs/terminal-interaction.md
+++ b/docs/terminal-interaction.md
@@ -1,0 +1,104 @@
+# Terminal Interaction Guide
+
+This document explains how terminal interaction works in AgentIsland and how to set up supported backends.
+
+## Overview
+
+AgentIsland terminal interactions include:
+
+- Sending chat input to an agent terminal
+- Sending interrupt key (`Esc`)
+- Sending terminate command (`/exit` / `/quit` based on agent)
+- Jumping to the agent terminal session
+
+Terminal backend is selected from app settings (`Terminal`: `tmux` or `cmux`).
+
+## Supported Backends
+
+- `tmux`
+- `cmux`
+
+## Common Requirements
+
+- Agent session must have a valid terminal context (TTY/session mapping)
+- Backend executable/socket must be reachable
+- Backend access permissions must allow AgentIsland operations
+
+## tmux Setup
+
+Ensure `tmux` is installed and available in PATH:
+
+```bash
+which tmux && tmux -V
+```
+
+## cmux Setup
+
+### 1) CLI setup
+
+Run the official symlink command:
+
+```bash
+sudo ln -sf "/Applications/cmux.app/Contents/Resources/bin/cmux" /usr/local/bin/cmux
+```
+
+Official guide (CLI setup section):
+
+- https://cmux.com/docs/getting-started#CLI%20setup
+
+Verify:
+
+```bash
+which cmux && cmux --version
+```
+
+### 2) Socket path
+
+AgentIsland uses cmux socket API. Ensure socket is reachable:
+
+- Default path: `/tmp/cmux.sock`
+- Or custom path via `CMUX_SOCKET_PATH`
+
+Verify:
+
+```bash
+ls "$CMUX_SOCKET_PATH"  # or ls /tmp/cmux.sock
+```
+
+### 3) Access mode
+
+cmux access mode must allow AgentIsland connection (avoid denied external client access).
+
+Official reference:
+
+- https://cmux.com/docs/api#Access%20modes
+
+If you see:
+
+`Access denied — only processes started inside cmux can connect`
+
+adjust access mode accordingly.
+
+### 4) API probe
+
+Test cmux API connectivity:
+
+```bash
+printf '{"id":"probe","method":"system.identify","params":{}}\n' | nc -U "$CMUX_SOCKET_PATH"
+```
+
+If this succeeds, AgentIsland can generally proceed with cmux target resolution and message/key delivery.
+
+## Troubleshooting Checklist
+
+1. Confirm backend selected in AgentIsland matches your environment.
+2. Confirm executable/socket availability.
+3. Confirm access mode permits AgentIsland.
+4. Probe API (`system.identify`) manually.
+5. Check app logs:
+
+```bash
+log stream --level debug --predicate 'subsystem == "com.agentisland"'
+```
+
+For cmux-specific diagnostics, filter by category `CmuxRPC`.

--- a/docs/terminal-interaction.zh.md
+++ b/docs/terminal-interaction.zh.md
@@ -1,0 +1,104 @@
+# 终端交互指南
+
+本文档说明 AgentIsland 中的终端交互机制以及如何配置支持的后端。
+
+## 概述
+
+AgentIsland 的终端交互功能包括：
+
+- 向 Agent 终端发送聊天输入
+- 发送中断按键（`Esc`）
+- 发送终止命令（根据 Agent 类型使用 `/exit` 或 `/quit`）
+- 跳转到 Agent 终端会话
+
+终端后端通过应用设置选择（`Terminal`：`tmux` 或 `cmux`）。
+
+## 支持的后端
+
+- `tmux`
+- `cmux`
+
+## 通用要求
+
+- Agent 会话必须具有有效的终端上下文（TTY/会话映射）
+- 后端可执行文件/Socket 必须可访问
+- 后端访问权限必须允许 AgentIsland 操作
+
+## tmux 配置
+
+确保 `tmux` 已安装且在 PATH 中可用：
+
+```bash
+which tmux && tmux -V
+```
+
+## cmux 配置
+
+### 1) CLI 设置
+
+运行官方符号链接命令：
+
+```bash
+sudo ln -sf "/Applications/cmux.app/Contents/Resources/bin/cmux" /usr/local/bin/cmux
+```
+
+官方指南（CLI 设置部分）：
+
+- https://cmux.com/docs/getting-started#CLI%20setup
+
+验证：
+
+```bash
+which cmux && cmux --version
+```
+
+### 2) Socket 路径
+
+AgentIsland 使用 cmux Socket API。确保 Socket 可访问：
+
+- 默认路径：`/tmp/cmux.sock`
+- 或通过 `CMUX_SOCKET_PATH` 环境变量指定自定义路径
+
+验证：
+
+```bash
+ls "$CMUX_SOCKET_PATH"  # 或 ls /tmp/cmux.sock
+```
+
+### 3) 访问模式
+
+cmux 访问模式必须允许 AgentIsland 连接（避免拒绝外部客户端访问）。
+
+官方参考：
+
+- https://cmux.com/docs/api#Access%20modes
+
+如果看到以下提示：
+
+`Access denied — only processes started inside cmux can connect`
+
+请相应调整访问模式。
+
+### 4) API 探测
+
+测试 cmux API 连通性：
+
+```bash
+printf '{"id":"probe","method":"system.identify","params":{}}\n' | nc -U "$CMUX_SOCKET_PATH"
+```
+
+如果探测成功，AgentIsland 通常可以正常进行 cmux 目标解析和消息/按键传递。
+
+## 故障排查清单
+
+1. 确认 AgentIsland 中选择的后端与你的环境匹配。
+2. 确认可执行文件/Socket 可用。
+3. 确认访问模式允许 AgentIsland 连接。
+4. 手动探测 API（`system.identify`）。
+5. 检查应用日志：
+
+```bash
+log stream --level debug --predicate 'subsystem == "com.agentisland"'
+```
+
+如需 cmux 专属诊断信息，可按 category `CmuxRPC` 进行过滤。

--- a/scripts/relaunch-exported-app.sh
+++ b/scripts/relaunch-exported-app.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Relaunch the freshly built app from build/export by force-quitting any running instance first.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+APP_PATH="$PROJECT_DIR/build/export/Agent Island.app"
+
+if [ ! -d "$APP_PATH" ]; then
+    echo "ERROR: App not found at: $APP_PATH"
+    echo "Please run ./scripts/build.sh first."
+    exit 1
+fi
+
+echo "Force quitting running Agent Island instance(s)..."
+killall -9 "Agent Island" >/dev/null 2>&1 || true
+killall -9 "AgentIsland" >/dev/null 2>&1 || true
+
+echo "Launching: $APP_PATH"
+open "$APP_PATH"
+
+echo "Done."


### PR DESCRIPTION
Summary

  - Add pluggable terminal multiplexer backend system with support for both tmux and cmux
  - Introduce TerminalMultiplexerAdapter protocol with registry pattern to abstract terminal
  interactions
  - Add cmux RPC client with Unix socket communication for workspace/surface management, text input,
   and key delivery
  - Refactor YabaiController to dispatch to the correct backend based on user settings
  - Add settings UI for terminal backend selection in the notch menu

  Key Changes

  New architecture — terminal multiplexer abstraction
  - TerminalMultiplexerAdapter protocol (Services/Terminal/) — unified interface for sending
  messages, special keys, and checking session state
  - TerminalMultiplexerRegistry — maps TerminalBackend enum to concrete adapter
  - TmuxTerminalMultiplexerAdapter / CmuxTerminalMultiplexerAdapter — backend implementations

  cmux integration (Services/Cmux/)
  - CmuxRPCClient — JSON-RPC over Unix socket (/tmp/cmux.sock or CMUX_SOCKET_PATH env)
  - CmuxTargetFinder — resolves agent PID / TTY / working directory to cmux workspaceId + surfaceId
  - CmuxController — high-level API wrapping finder + RPC client

  UI
  - TerminalPickerRow + TerminalOptionRow — dropdown picker in settings menu
  - Renamed isInTmux → isInTerminalMultiplexer across chat views and approval bars
  - Chat input placeholder now reflects selected backend name

  Misc
  - @MainActor annotations on AppDelegate and WindowManager
  - .gitignore updates for code agent artifacts
  - Added CLAUDE.md, terminal interaction docs (EN/ZH), relaunch helper script

  Test plan

  - Verify tmux backend works as before (send message, interrupt, jump to terminal)
  - Select cmux backend in settings, confirm messages deliver to correct surface
  - Test cmux target resolution via TTY, agent PID, and working directory fallback paths
  - Confirm CMUX_SOCKET_PATH env override works
  - Verify UI picker saves selection to UserDefaults and persists across launches
  - Test approval bars and interactive prompts show correct state with both backends